### PR TITLE
Add support for distribution version of ISC Kea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (2019) Petr Ospalý <petr@ospalax.cz>
+# Copyright (2019-2021) Petr Ospalý <pospaly@opennebula.io>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -22,6 +22,7 @@ $(BUILD_DIR)/$(IKEA_PKG)-$(KEA_VERSION)-alpine$(ALPINE_VERSION).tar.xz: docker
 		-e "KEA_INSTALLPREFIX=$(KEA_INSTALLPREFIX)" \
 		-e "IKEA_PKG=$(IKEA_PKG)" \
 		-e "KEA_VERSION=$(KEA_VERSION)" \
+		-e "USE_DISTRO_PACKAGE=$(USE_DISTRO_PACKAGE)" \
 		-e "ALPINE_VERSION=$(ALPINE_VERSION)" \
 		-e "UID_GID=$$(getent passwd $$(id -u) | cut -d":" -f3,4)" \
 		-v "$$(realpath '$(BUILD_DIR)'):/build/:rw" \
@@ -55,6 +56,7 @@ docker: Dockerfile build.sh
 		KEEP_BUILDBLOB="$(KEEP_BUILDBLOB)" \
 		KEEP_BUILDDEPS="$(KEEP_BUILDDEPS)" \
 		INSTALL_HOOKS="$(INSTALL_HOOKS)" \
+		USE_DISTRO_PACKAGE="$(USE_DISTRO_PACKAGE)" \
 		BUILD_DIR="$(BUILD_DIR)" \
 		tools/docker-build.sh
 # It could be so simple, but that pipe with tee is hiding the failure of the
@@ -67,6 +69,7 @@ docker: Dockerfile build.sh
 #		--build-arg KEEP_BUILDBLOB=$(KEEP_BUILDBLOB) \
 #		--build-arg KEEP_BUILDDEPS=$(KEEP_BUILDDEPS) \
 #		--build-arg INSTALL_HOOKS=$(INSTALL_HOOKS) \
+#		--build-arg USE_DISTRO_PACKAGE=$(USE_DISTRO_PACKAGE) \
 #		. | tee "$(BUILD_DIR)/$(IKEA_TAG)-$(KEA_VERSION)-build.log"
 
 clean:

--- a/Makefile.config
+++ b/Makefile.config
@@ -32,3 +32,6 @@ KEEP_BUILDDEPS ?= no
 
 # build and install hooks (for the relevant kea version)
 INSTALL_HOOKS ?= yes
+
+# skip ISC Kea build and try to use distribution version
+USE_DISTRO_PACKAGE ?= no

--- a/extra/README.md
+++ b/extra/README.md
@@ -2,4 +2,4 @@
 
 Here are simple scripts to run particular builds in the consistent matter.
 
-- `onekea.sh` for OpenNebula's VNF appliance
+- `onekea.sh` for [OpenNebula's VNF appliance](https://docs.opennebula.io/appliances/service/vnf.html)

--- a/extra/onekea.sh
+++ b/extra/onekea.sh
@@ -2,9 +2,11 @@
 
 set -ex
 
-ALPINE_VERSION=${ALPINE_VERSION:-3.11}
-KEA_VERSION=${KEA_VERSION:-1.6.1}
-KEA_INSTALLPREFIX=/opt/one-appliance/kea
+ALPINE_VERSION=${ALPINE_VERSION:-3.13}
+KEA_VERSION=${KEA_VERSION:-1.8.2}
+#KEA_INSTALLPREFIX=/opt/one-appliance/kea
+USE_DISTRO_PACKAGE=yes
+KEA_INSTALLPREFIX=/usr # using the distribution version which is under /usr
 MAKE_JOBS="${MAKE_JOBS:-4}"
 IKEA_TAG=onekea
 IKEA_IMG=onekea-image
@@ -19,6 +21,7 @@ export IKEA_TAG
 export IKEA_IMG
 export IKEA_PKG
 export INSTALL_HOOKS
+export USE_DISTRO_PACKAGE
 
 WORKDIR=$(git rev-parse --show-toplevel)
 

--- a/src/hooks/kea-onelease-dhcp4/1.8.2
+++ b/src/hooks/kea-onelease-dhcp4/1.8.2
@@ -1,0 +1,1 @@
+onelease4-v1.1

--- a/src/hooks/kea-onelease-dhcp4/onelease4-v1.1.0/Makefile
+++ b/src/hooks/kea-onelease-dhcp4/onelease4-v1.1.0/Makefile
@@ -42,6 +42,8 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cc
 install: all
 	@printf "\n# MAKE -> Copy hook library into Kea\n\n"
 	@cp -av "$(BUILD_DIR)/$(LIBHOOK)" "${KEA_INSTALLPREFIX}"/lib/kea/hooks/
+	@echo "${KEA_INSTALLPREFIX}/lib/kea/hooks/$(LIBHOOK)" \
+		>> "${KEA_INSTALLPREFIX}/lib/kea/hooks/opennebula-hooks.list"
 	@printf '\n# MAKE -> INSTALLATION DONE\n\n'
 
 clean:

--- a/tools/arkea.sh
+++ b/tools/arkea.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (2019) Petr Ospalý <petr@ospalax.cz>
+# Copyright (2019-2021) Petr Ospalý <pospaly@opennebula.io>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,6 +11,27 @@
 set -ex
 
 KEA_INSTALLPREFIX="${KEA_INSTALLPREFIX:-/usr/local}"
+
+#
+# functions
+#
+
+# arg: <variable name>
+is_true()
+{
+    _value=$(eval echo "\$${1}" | tr '[:upper:]' '[:lower:]')
+    case "$_value" in
+        yes|true)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+#
+# main
+#
 
 for i in \
     IKEA_PKG \
@@ -26,14 +47,24 @@ do
 done
 
 # here is expected that /build directory is provided as a bind mount for docker
-tar cJf "/build/${IKEA_PKG}-${KEA_VERSION}-alpine${ALPINE_VERSION}.tar.xz" \
-	"${KEA_INSTALLPREFIX}/etc" \
-	"${KEA_INSTALLPREFIX}/include" \
-	"${KEA_INSTALLPREFIX}/lib" \
-	"${KEA_INSTALLPREFIX}/sbin" \
-	"${KEA_INSTALLPREFIX}/share" \
-	"${KEA_INSTALLPREFIX}/var" \
-	/etc/ld-musl-$(arch).path
+
+if is_true USE_DISTRO_PACKAGE ; then
+    # we need only the compiled hook binary when distribution version is used
+    # and it is always under /usr
+    tar cJf "/build/${IKEA_PKG}-${KEA_VERSION}-alpine${ALPINE_VERSION}.tar.xz" \
+        /usr/lib/kea/hooks/opennebula-hooks.list \
+        $(cat /usr/lib/kea/hooks/opennebula-hooks.list)
+else
+    # archive the complete software suite including all hooks
+    tar cJf "/build/${IKEA_PKG}-${KEA_VERSION}-alpine${ALPINE_VERSION}.tar.xz" \
+    	"${KEA_INSTALLPREFIX}/etc" \
+    	"${KEA_INSTALLPREFIX}/include" \
+    	"${KEA_INSTALLPREFIX}/lib" \
+    	"${KEA_INSTALLPREFIX}/sbin" \
+    	"${KEA_INSTALLPREFIX}/share" \
+    	"${KEA_INSTALLPREFIX}/var" \
+    	/etc/ld-musl-$(arch).path
+fi
 
 chown "${UID_GID:-$(id -u).}" \
     "/build/${IKEA_PKG}-${KEA_VERSION}-alpine${ALPINE_VERSION}.tar.xz"

--- a/tools/docker-build.sh
+++ b/tools/docker-build.sh
@@ -63,6 +63,7 @@ for i in \
     KEEP_BUILDDEPS \
     INSTALL_HOOKS \
     BUILD_DIR \
+    USE_DISTRO_PACKAGE \
     ;
 do
     _value=$(eval echo "\"\$${i}\"")
@@ -88,6 +89,7 @@ docker build -t ${IKEA_TAG} \
     --build-arg KEEP_BUILDBLOB \
     --build-arg KEEP_BUILDDEPS \
     --build-arg INSTALL_HOOKS \
+    --build-arg USE_DISTRO_PACKAGE \
     .
 
 # let's create all relevant tags


### PR DESCRIPTION
- Add new build parameter 'USE_DISTRO_PACKAGE'
- Add support for installing distribution version of Kea and build hooks
  against that build version
- Bump ONE ISC Kea to 1.8.2 and Alpine to 3.13 and usage of the distro
  supplied version of ISC Kea
- Save a list of custom OpenNebula's hooks inside the Kea's hook
  directory
- Archive only the custom OpenNebula's hooks when distro version is used
- Prefer stable version of log4cplus
- Update license header

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>